### PR TITLE
Rename module name to "resin-jwt"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git@bitbucket.org:rulemotion/resin-jwt"
+    "url": "git@github.com:resin-io-modules/resin-jwt.git"
   },
   "author": "Aleksis Brezas <abresas@resin.io>",
   "scripts": {


### PR DESCRIPTION
Closes #1 

After this is merged, this module and all its versions (latest `1.0.6` and past) will be published in npm as `resin-jwt@<version>`